### PR TITLE
urlib  shenanigans

### DIFF
--- a/atomic_datasets/utils/download.py
+++ b/atomic_datasets/utils/download.py
@@ -8,6 +8,7 @@ import git
 import zipfile
 import tarfile
 import urllib
+import urllib.request
 
 
 def clone_url(url: str, root: str) -> str:


### PR DESCRIPTION
Was getting this

```python
>>> for graph in dataset:
...    print(graph["nodes"])
... 
Downloading QM9 dataset to data/qm9
Traceback (most recent call last):
  File "/home/mkotak/atomic_architects/projects/datasets/atomic_datasets/utils/download.py", line 36, in download_url
    data = urllib.request.urlopen(url)
           ^^^^^^^^^^^^^^
AttributeError: module 'urllib' has no attribute 'request'
```

Got the fix from [here](https://stackoverflow.com/questions/37042152/python-3-5-1-urllib-has-no-attribute-request)
